### PR TITLE
better support for prod/dev container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+.editorconfig
+.idea
+node_modules
+*.log
+*.md

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 web:
   build: .
+  command: npm run dev
   volumes:
     - .:/code
   environment:

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "TARGET=build webpack",
-    "start": "TARGET=dev webpack-dev-server --devtool eval --progress --colors --hot --inline --history-api-fallback --host 0.0.0.0",
-    "winstart": "webpack-dev-server --devtool eval --progress --colors --hot --inline --history-api-fallback",
+    "dev": "TARGET=dev webpack-dev-server --devtool eval --progress --colors --hot --inline --history-api-fallback --host 0.0.0.0",
+    "windev": "webpack-dev-server --devtool eval --progress --colors --hot --inline --history-api-fallback",
+    "start": "nodemon server.js",
     "postinstall": "cp -a ./node_modules/bootswatch/bower_components/bootstrap/fonts ./node_modules/bootswatch"
   },
   "dependencies": {
@@ -22,6 +23,7 @@
     "lodash": "^3.8.0",
     "moment": "^2.10.3",
     "moment-duration-format": "^1.3.0",
+    "nodemon": "^1.4.0",
     "react": "^0.13.3",
     "react-bootstrap": "^0.22.3",
     "react-router": "^0.13.3",

--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
 var http = require('http');
-var port = process.argv[2];
+var port = process.argv[2] || 4040;
 
 http.createServer(function (req, res) {
   res.writeHead(200, {'Content-Type': 'text/plain'});


### PR DESCRIPTION
package.json start script should we what runs the server and the server shoudl serve the initial page. I made a dev and windev command for the webpack dev server. `npm run dev` or `npm run windev` is how you invoke it.
